### PR TITLE
Giving chef-solo an absolute path

### DIFF
--- a/config/solo.rb
+++ b/config/solo.rb
@@ -7,7 +7,7 @@
 #
 
 file_cache_path "/var/chef/cache"
-cookbook_path [ File.join(File.dirname(__FILE__), '../cookbooks') ]
-role_path File.join(File.dirname(__FILE__), '../roles')
+cookbook_path [ File.expand_path(File.join(File.dirname(__FILE__), '../cookbooks')) ]
+role_path File.expand_path(File.join(File.dirname(__FILE__), '../roles'))
 log_level :info
 


### PR DESCRIPTION
chef-solo didn't found the cookbooks using relative paths. 

``` ruby
File.expand_path() 
```

gives the full absolute path
